### PR TITLE
[fr] add missing French label for "Make Presentations Accessible"

### DIFF
--- a/navigation.yml
+++ b/navigation.yml
@@ -405,7 +405,9 @@
   - name: Changelog
     url: "/teach-advocate/changelog/"
     hide: true
-  - name: Make Presentations Accessible
+  - name:
+      en: 'Make Presentations Accessible'
+      fr: 'Des présentations accessibles'
     url: "/teach-advocate/accessible-presentations/"
   - name: Curricula on Web Accessibility
     url: "/curricula/"


### PR DESCRIPTION
an existing French version of "Make Presentations Accessible" page is missing a French label in the navigation menu