### PR TITLE
Sidebar Reuse of Existing H2 IDs

### DIFF
--- a/theme-plugin.rb
+++ b/theme-plugin.rb
@@ -43,7 +43,9 @@ module Jekyll
         # Convert text to be suitable for a URl fragment and HTML element id
         # Both HTML5 id and URL fragment are very flxible so we just strip whitespace (not lf)
         def fragmentify(text)
-            return text.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
+            return text
+            .downcase
+            .gsub(/[\s]/, '')
         end
     end
   end

--- a/theme-plugin.rb
+++ b/theme-plugin.rb
@@ -14,24 +14,26 @@ module Jekyll
 
         # Ads id attribute to H2 based on text
         def add_h2_ids(content)
-        doc = Nokogiri::HTML5.fragment(content)
-# TODO maybe add option to print errors like this
-# As it is this will change the content if html is invalid.
-#        doc = Nokogiri::HTML5.fragment(content, max_errors: 10)  
-#        doc.errors.each do |err|
-#            puts(err)
-#        end
-        doc.css('h2').each do |h2|
-            h2['id'] = fragmentify h2.text 
-        end
-        return doc.to_s
+            doc = Nokogiri::HTML5.fragment(content)
+            # TODO maybe add option to print errors like this
+            # As it is this will change the content if html is invalid.
+            #        doc = Nokogiri::HTML5.fragment(content, max_errors: 10)  
+            #        doc.errors.each do |err|
+            #            puts(err)
+            #        end
+            doc.css('h2').each do |h2|
+                if !h2['id']
+                    h2['id'] = fragmentify h2.text
+                end
+            end
+            return doc.to_s
         end
 
         # Get an array of links
         def get_h2_links(content)
             doc = Nokogiri::HTML5.fragment(content)
             names = doc.css('h2').map { |h2| h2.text }
-            ids = names.map { |name| fragmentify name }
+            ids = doc.css('h2').map { |h2| h2['id'] }
             links = names.zip( ids )
             return links
         end
@@ -41,9 +43,7 @@ module Jekyll
         # Convert text to be suitable for a URl fragment and HTML element id
         # Both HTML5 id and URL fragment are very flxible so we just strip whitespace (not lf)
         def fragmentify(text)
-            return text
-            .downcase
-            .gsub(/[\s]/, '') 
+            return text.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
         end
     end
   end


### PR DESCRIPTION
This fixes an issue in the [wai-aria-practices repo](https://github.com/w3c/wai-aria-practices) where "open in codepen" buttons failed to load. After some investigation we found out that the sidebar code had changed the h2's ids. This was the cause of the issue. This PR will update the sidebar code to only set the h2's id if it's missing, and to use the existing id if it's present.