### PR TITLE
Address invalid breadcrumb navigation fallback

### DIFF
--- a/navigation.yml
+++ b/navigation.yml
@@ -45,7 +45,7 @@
           fr: 'Changements'
           es: 'Registro de cambios'
         url: /videos/standards-and-benefits/changelog/
-        hide: true        
+        hide: true
   - name: "Accessibility is About People"
     url: "/people/"
     pages:
@@ -142,7 +142,7 @@
       pages:
       - name: Submit a course
         url: "/courses/submission/"
-        hide: true	
+        hide: true
 - name:
     en: 'Planning & Policies'
     es: 'Planificación y Políticas'
@@ -738,4 +738,7 @@
   mainnav: false
 - name: Cognitive Accessibility Guidance - Here in March 2022
   url: "/WCAG2/supplemental/"
+  mainnav: false
+- name: ...
+  url: "/"
   mainnav: false

--- a/navigation.yml
+++ b/navigation.yml
@@ -739,6 +739,11 @@
 - name: Cognitive Accessibility Guidance - Here in March 2022
   url: "/WCAG2/supplemental/"
   mainnav: false
+
+# NOTE that this is a "magic" fix in combination with w3c/wai-website-theme/_includes/header.html#L169.
+# '...' should stay at the bottom. Jekyll seems to be defaulting the last item in this file when a page is no
+# longer included in the main navigation. https://www.w3.org/WAI/standards-guidelines/wcag-mobile-overlap/.
+# The url should never be shown but it has been set as a "just-in-case"
 - name: ...
   url: "/"
   mainnav: false

--- a/navigation.yml
+++ b/navigation.yml
@@ -741,9 +741,11 @@
   mainnav: false
 
 # NOTE that this is a "magic" fix in combination with w3c/wai-website-theme/_includes/header.html#L169.
-# '...' should stay at the bottom. Jekyll seems to be defaulting the last item in this file when a page is no
-# longer included in the main navigation. https://www.w3.org/WAI/standards-guidelines/wcag-mobile-overlap/.
-# The url should never be shown but it has been set as a "just-in-case"
+# '...' should stay at the bottom. Jekyll seems to be defaulting the breadcrumbs nav to the last item in this file when
+# a page isn't included in the main navigation. Furthermore, it causes an unexpected navigation to an unexpected URL,
+# Which is what has prompted the need for also updating wai-website-theme. An example of the issue can be seen on
+# https://www.w3.org/WAI/standards-guidelines/wcag-mobile-overlap/.
+# Also note, the URL is never intended to be accessed, but it has been set as a "just-in-case"
 - name: ...
   url: "/"
   mainnav: false


### PR DESCRIPTION
This is to address an issue where, whenever a page is not included under a main navigation parent, it causes the breadcrumb component on the page to be incorrectly defaulted to the last item in `navigation.yml`. An example can be seen at https://www.w3.org/WAI/standards-guidelines/wcag-mobile-overlap/

Note that this works in combination with https://github.com/w3c/wai-website-theme/pull/53, as the link the breadcrumb redirects to is also unexpected and not the `URL` the last item in `navigation.yml` references.

**How to test**
1. Clone https://github.com/w3c/wai-website
2. Setup wai-website locally as expected
3. Add the following to the bottom of `_external/data/navigation.yml` (Note that this is just the gitmodule folder for `wai-website-data`)
```yml
- name: ...
  url: "/"
  mainnav: false
```
4. Update the `_config.yml` file's `remote_theme` to be `howard-e/wai-website-theme`
5. Run wai-website locally as expected and observe the breadcrumbs on https://localhost/WAI/standards-guidelines/wcag-mobile-overlap/