### PR TITLE
Fixing typo in navigation

### DIFF
--- a/navigation.yml
+++ b/navigation.yml
@@ -456,7 +456,7 @@
         url: "/test-evaluate/easy-checks/skip-link/"
       - name: Keyboard Focus
         url: "/test-evaluate/easy-checks/keyboard-focus/"
-      - name: Langage of Page
+      - name: Language of Page
         url: "/test-evaluate/easy-checks/language/"
       - name: Zoom
         url: "/test-evaluate/easy-checks/zoom/"


### PR DESCRIPTION
Fixing a typo in the left hand nav for Easy Checks (changing langage to language)