### PR TITLE
Change Translation Priorities Order

### DIFF
--- a/translations-priorities.yml
+++ b/translations-priorities.yml
@@ -1,5 +1,7 @@
 - url: "/videos/standards-and-benefits/"
 - url: "/fundamentals/accessibility-intro/"
+- url: "/fundamentals/accessibility-principles/"
+- url: "/standards-guidelines/wcag/"
 - url: "/people-use-web/"
 - url: "/people-use-web/user-stories/"
   pages:
@@ -43,5 +45,3 @@
     - url: "/tips/designing/"
     - url: "/tips/developing/"
 - url: "/tutorials/images/decision-tree/"
-- url: "/fundamentals/accessibility-principles/"
-- url: "/standards-guidelines/wcag/"


### PR DESCRIPTION
Related to https://github.com/w3c/wai-website/issues/856

> change the order to:
>
> a. [Video Introduction to Web Accessibility and W3C Standards](https://www.w3.org/WAI/videos/standards-and-benefits/)
> b. [Introduction to Web Accessibility](https://www.w3.org/WAI/fundamentals/accessibility-intro/)
> c. [Accessibility Principles](https://www.w3.org/WAI/fundamentals/accessibility-principles/)
> d. [WCAG 2 Overview](https://www.w3.org/WAI/standards-guidelines/wcag/)