### PR TITLE
Navigation: Working groups and task forces

### DIFF
--- a/navigation.yml
+++ b/navigation.yml
@@ -1010,10 +1010,10 @@
   - name: Groups
     url: "/about/groups/"
     pages:
-    - name: 'Accessibility Guidelines <abbr title="Working Group">WG</abbr>'
+    - name: 'Accessibility Guidelines>'
       url: "/about/groups/agwg/"
       pages:
-      - name: 'Accessibility Conformance Testing <abbr title="Task Force">TF</abbr>'
+      - name: 'Accessibility Conformance Testing'
         url: "/about/groups/task-forces/conformance-testing/"
         pages:
         - name: Work Statement
@@ -1031,7 +1031,7 @@
         - name: Meeting Topics
           url: "/about/groups/task-forces/conformance-testing/minutes/topics/"
           hide: true
-      - name: 'Cognitive and Learning Disabilities <abbr title="Task Force">TF</abbr>'
+      - name: 'Cognitive and Learning Disabilities'
         url: "/about/groups/task-forces/coga/"
         pages:
         - name: Work Statement
@@ -1046,7 +1046,7 @@
         - name: Meeting Topics
           url: "/about/groups/task-forces/coga/minutes/topics/"
           hide: true
-      - name: 'Low Vision Accessibility <abbr title="Task Force">TF</abbr>'
+      - name: 'Low Vision Accessibility'
         url: "/about/groups/task-forces/low-vision-a11y-tf/"
         pages:
         - name: Work Statement
@@ -1061,7 +1061,7 @@
         - name: Meeting Topics
           url: "/about/groups/task-forces/low-vision-a11y-tf/minutes/topics/"
           hide: true
-      - name: 'Mobile Accessibility <abbr title="Task Force">TF</abbr>'
+      - name: 'Mobile Accessibility'
         url: "/about/groups/task-forces/matf/"
         pages:
         - name: Work Statement
@@ -1076,13 +1076,13 @@
         - name: Meeting Topics
           url: "/about/groups/task-forces/matf/minutes/topics/"
           hide: true
-      - name: 'WCAG 2.x Backlog <abbr title="Task Force">TF</abbr>'
+      - name: 'WCAG 2.x Backlog'
         url: "/about/groups/task-forces/wcag2x-backlog/"
         pages:
         - name: Work Statement
           url: "/about/groups/task-forces/wcag2x-backlog/work-statement/"
           hide: true
-      - name: 'WCAG2ICT <abbr title="Task Force">TF</abbr>'
+      - name: 'WCAG2ICT'
         url: "/about/groups/task-forces/wcag2ict/"
         pages:
         - name: Work Statement
@@ -1109,10 +1109,10 @@
       - name: Meeting Topics
         url: "/about/groups/agwg/minutes/topics/"
         hide: true
-    - name: 'Accessible Platform Architectures <abbr title="Working Group">WG</abbr>'
+    - name: 'Accessible Platform Architectures>'
       url: "/about/groups/apawg/"
       pages:
-      - name: 'Framework for Accessible Specification of Technologies <abbr title="Task Force">TF</abbr>'
+      - name: 'Framework for Accessible Specification of Technologies'
         url: "/about/groups/task-forces/fast/"
         pages:
         - name: Work Statement
@@ -1127,7 +1127,7 @@
         - name: Meeting Topics
           url: "/about/groups/task-forces/fast/minutes/topics/"
           hide: true
-      - name: 'Maturity Model <abbr title="Task Force">TF</abbr>'
+      - name: 'Maturity Model'
         url: "/about/groups/task-forces/maturity-model/"
         pages:
         - name: Work Statement
@@ -1142,7 +1142,7 @@
         - name: Meeting Topics
           url: "/about/groups/task-forces/maturity-model/minutes/topics/"
           hide: true
-      - name: 'Research Questions <abbr title="Task Force">TF</abbr>'
+      - name: 'Research Questions'
         url: "/about/groups/task-forces/research-questions/"
         pages:
         - name: Work Statement
@@ -1157,7 +1157,7 @@
         - name: Meeting Topics
           url: "/about/groups/task-forces/research-questions/minutes/topics/"
           hide: true
-      - name: 'Spoken Presentation <abbr title="Task Force">TF</abbr>'
+      - name: 'Spoken Presentation'
         url: "/about/groups/task-forces/spoken-presentation/"
         pages:
         - name: Work Statement
@@ -1172,7 +1172,7 @@
         - name: Meeting Topics
           url: "/about/groups/task-forces/spoken-presentation/minutes/topics/"
           hide: true
-      - name: 'WAI-Adapt <abbr title="Task Force">TF</abbr>'
+      - name: 'WAI-Adapt'
         url: "/about/groups/task-forces/adapt/"
         pages:
         - name: Work Statement
@@ -1199,10 +1199,10 @@
       - name: Meeting Topics
         url: "/about/groups/apawg/minutes/topics/"
         hide: true
-    - name: 'ARIA <abbr title="Working Group">WG</abbr>'
+    - name: 'ARIA>'
       url: "/about/groups/ariawg/"
       pages:
-      - name: 'ARIA Authoring Practices <abbr title="Task Force">TF</abbr>'
+      - name: 'ARIA Authoring Practices'
         url: "/about/groups/task-forces/practices/"
         pages:
         - name: Work Statement
@@ -1217,7 +1217,7 @@
         - name: Meeting Topics
           url: "/about/groups/task-forces/practices/minutes/topics/"
           hide: true
-      - name: 'PDF Accessibility <abbr title="Application Programming Interfaces">APIs</abbr> Mapping <abbr title="Task Force">TF</abbr>'
+      - name: 'PDF Accessibility <abbr title="Application Programming Interfaces">APIs</abbr> Mapping'
         url: "/about/groups/task-forces/pdf-aam/"
         pages:
         - name: Work Statement
@@ -1246,10 +1246,10 @@
         hide: true
     - name: 'WAI Interest Group'
       url: "/about/groups/waiig/"
-    - name: 'Previous groups'
+    - name: 'Past groups'
       url: "/about/groups/previous-groups/"
       pages:
-      - name: 'Education and Outreach <abbr title="Working Group">WG</abbr>'
+      - name: 'Education and Outreach>'
         url: "/about/groups/eowg/"
         hide: true
         pages:
@@ -1259,14 +1259,14 @@
           - name: Participants
             url: "/about/groups/eowg/participants/"
             hide: true
-      - name: 'CSS Accessibility <abbr title="Task Force">TF</abbr>'
+      - name: 'CSS Accessibility'
         url: "/about/groups/task-forces/css-a11y/"
         hide: true
         pages:
           - name: Work Statement
             url: "/about/groups/task-forces/css-a11y/work-statement/"
             hide: true
-      - name: 'Silver <abbr title="Task Force">TF</abbr>'
+      - name: 'Silver'
         url: "/about/groups/task-forces/silver/"
         hide: true
         pages:


### PR DESCRIPTION
Includes some changes from https://github.com/w3c/wai-website-data/pull/207/ that do not alter existing URLs.

- Remove WG and TF abbr elements
- Previous groups -> Past groups