### PR TITLE
hide individual project pages — Update navigation.yml 

### DIFF
--- a/navigation.yml
+++ b/navigation.yml
@@ -1346,7 +1346,8 @@
     pages:
     - name: WAI-CooP
       url: "/about/projects/wai-coop/"
-      pages:
+      hide: true
+	  pages:
       - name: Research Symposium 2021
         url: "/about/projects/wai-coop/symposium1/"
       - name: Research Symposium AI
@@ -1355,8 +1356,10 @@
         url: "/about/projects/wai-coop/symposium3/"
     - name: WAI-Guide
       url: "/about/projects/wai-guide/"
+	  hide: true
     - name: WAI-Tools
       url: "/about/projects/wai-tools/"
+	  hide: true
       pages:
       - name: Final Open Meeting
         url: "/about/projects/wai-tools/final-open-meeting/"
@@ -1383,12 +1386,16 @@
         url: "/about/projects/wai-tools/first-open-meeting/"
     - name: WAI Expanding Access
       url: "/expand-access/"
+	  hide: true
     - name: Easy Reading
       url: "/about/projects/easy-reading/"
+	  hide: true
     - name: WAI-Core US
       url: "/about/projects/wai-core-us/"
+	  hide: true
     - name: WAI-Core Ford
       url: "/about/projects/wai-core-ford/"
+	  hide: true
   - name: Accessibility Statement
     url: "/about/accessibility-statement/"
   - name: Using WAI Material


### PR DESCRIPTION
goal:

- When on the [About > Projects page](https://www.w3.org/WAI/about/projects/), none of the projects are listed in the left nav.
- When on a specific project page, e.g., [WAI-CooP](https://www.w3.org/WAI/about/projects/wai-coop/), only it (and any of its sub-pages) are listed in the left nav.


@remibetin Does this PR achieve that? :)